### PR TITLE
Fix default click handler

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -99,8 +99,21 @@
           $('#count2').text(n);
         }
 
+        function show_action(stop, selected) {
+          var action;
+          console.log(stop);
+          if (selected) {
+            action = "Selected stop " + stop.properties.stop.stop_id;
+          }
+          else {
+            action = "Deselected stop " + stop.properties.stop.stop_id;
+          }
+          console.log(action);
+          $('#action2').text(action);
+        }
+
         var chooser1 = BusStopChooser.create({
-          api_token: TOKEN
+          api_token: TOKEN,
         });
 
         var chooser2 = BusStopChooser.create({
@@ -109,6 +122,7 @@
           popups: true,
           location: true,
           stops_callback: show_count,
+          on_click_stop_callback: show_action,
         });
 
         $().ready(function () {
@@ -137,6 +151,8 @@
 
     <div id="chooser1" style="height: 500px; width: 500px; border: 1px solid black;"></div>
 
+
+
     <button id="save1" name="button">Save</button>
 
     <pre id="results1">None</pre>
@@ -144,6 +160,8 @@
     <div id="chooser2" style="height: 500px; width: 500px; border: 1px solid black;"></div>
 
     <div>Stops selected: <span id="count2">None</span></div>
+
+    <div>Action: <span id="action2">None</span></div>
 
     <button id="save2" name="button">Save</button>
 

--- a/src/bus_stop_chooser.js
+++ b/src/bus_stop_chooser.js
@@ -401,18 +401,24 @@ var BusStopChooser = (function() {
 
                 var clicked_marker = e.target;
 
-                var selected = false;
+                // Work out if this stop was already selected
+                var already_selected = false;
                 selected_stops.eachLayer(function(marker) {
                     if (clicked_marker === marker) {
-                        selected = true;
+                        already_selected = true;
                     }
                 });
 
                 if (on_click_stop_callback) {
-                    on_click_stop_callback(clicked_marker, selected);
+                    on_click_stop_callback(clicked_marker, !already_selected);
                 }
 
-                select_or_deselect_stop(clicked_marker, selected);
+                if (already_selected) {
+                    deselect_stop(clicked_marker);
+                }
+                else {
+                    select_stop(clicked_marker);
+                }
 
                 do_stops_callback();
 
@@ -420,25 +426,35 @@ var BusStopChooser = (function() {
 
             }
 
-            function select_or_deselect_stop(marker, selected) {
-                if (selected) {
-                    // First remove anything currently selected if not multi_select
-                    // [*should* only ever be one, but who knows?]
-                    if (!multi_select) {
-                        selected_stops.eachLayer(function(m) {
-                            deselect_stop(m);
-                        });
-                    }
-                    other_stops.removeLayer(marker);
-                    marker.addTo(selected_stops);
-                    marker.setIcon(stop_icon_selected);
-                } else {
-                    selected_stops.removeLayer(marker);
-                    marker.addTo(other_stops);
-                    marker.setIcon(stop_icon);
+
+            function select_stop(marker) {
+                // First remove anything currently selected if not multi_select
+                // [*should* only ever be one, but who knows?]
+                if (!multi_select) {
+                    selected_stops.eachLayer(function(m) {
+                        deselect_stop(m);
+                    });
                 }
-                debug_log(selected ? 'Selected' : 'Deselected', marker);
+                other_stops.removeLayer(marker);
+                marker.addTo(selected_stops);
+                marker.setIcon(stop_icon_selected);
+                if (popups) {
+                    //marker.openPopup();
+                }
+                debug_log('Selected', marker);
             }
+
+
+            function deselect_stop(marker) {
+                selected_stops.removeLayer(marker);
+                marker.addTo(other_stops);
+                marker.setIcon(stop_icon);
+                if (popups) {
+                    //marker.openPopup();
+                }
+                debug_log('Deselected', marker);
+            }
+
 
             function list_selected_stops() {
                 // Return the stop_ids of currently selected stops

--- a/src/bus_stop_chooser.js
+++ b/src/bus_stop_chooser.js
@@ -438,9 +438,6 @@ var BusStopChooser = (function() {
                 other_stops.removeLayer(marker);
                 marker.addTo(selected_stops);
                 marker.setIcon(stop_icon_selected);
-                if (popups) {
-                    //marker.openPopup();
-                }
                 debug_log('Selected', marker);
             }
 
@@ -449,9 +446,6 @@ var BusStopChooser = (function() {
                 selected_stops.removeLayer(marker);
                 marker.addTo(other_stops);
                 marker.setIcon(stop_icon);
-                if (popups) {
-                    //marker.openPopup();
-                }
                 debug_log('Deselected', marker);
             }
 


### PR DESCRIPTION
An earlier change stopped the internal stop click handler from working,
making it impossible to actually select or deselect stops. This edit
reverts the broken change and renames a variable ('selected' -->
'already_selected') to reduce the potential for the confusion that lead
to the breakage.

Note this restores the separate select_stop() and deselect_stop() functions because select_stop() needs to call deselect_stop().

This edit also adds a demo of the new on_click_stop_callback parameter
to demo.html.